### PR TITLE
Fixed SyntaxError in `admin_command.py` when running `advisor_admin server start`

### DIFF
--- a/advisor_client/advisor_client/commandline/admin_command.py
+++ b/advisor_client/advisor_client/commandline/admin_command.py
@@ -107,7 +107,7 @@ def is_server_running():
     if command_output != "":
       return True
 
-  except subprocess.CalledProcessError, e:
+  except subprocess.CalledProcessError as e:
     if e.output == "":
       pass
     else:


### PR DESCRIPTION
This is a pull request to solve Issue #20. The only proposed change is to change the following line in `admin_command.py`:

```
    except subprocess.CalledProcessError, e:
```

to

```
    except subprocess.CalledProcessError as e:
```  

to fix compatibility with Python 3.x. Note that it might break compatibility with Python versions 2.5 and below.
Note that 