### PR TITLE
Fix bug of delete operation in dashboard

### DIFF
--- a/advisor_server/dashboard/templates/index.html
+++ b/advisor_server/dashboard/templates/index.html
@@ -49,7 +49,7 @@
                     <td class="text-center success">{{ study.updated_time }}</td>
                     <td class="text-center warning">
                         <input type="image" width="22px" src="/static/images/delete-icon.png" alt="Delete"
-                               onclick="delete_resource('/dashboard/v1/studies/{{ study.id }}')"/>
+                               onclick="delete_resource('/dashboard/v1/studies/{{ study.name }}')"/>
                     </td>
                 </tr>
                 {% endfor %}


### PR DESCRIPTION
Delete operation icon use study id while v1_study in suggestion use study name to get the study. So I changed the delete icon's action to fix it.