### PR TITLE
choose bytes or str based on python 2 or 3

### DIFF
--- a/advisor_client/advisor_client/model.py
+++ b/advisor_client/advisor_client/model.py
@@ -1,3 +1,6 @@
+import six
+
+
 class Study(object):
   def __init__(self,
                name,
@@ -8,7 +11,10 @@ class Study(object):
                created_time=None,
                updated_time=None):
     self.id = id
-    self.name = name.encode("utf-8")
+    if six.PY2:
+      self.name = name.encode("utf-8")
+    else:
+      self.name = name
     self.study_configuration = study_configuration
     self.algorithm = algorithm
     self.status = status
@@ -44,7 +50,10 @@ class Trial(object):
                created_time=None,
                updated_time=None):
     self.id = id
-    self.study_name = study_name.encode("utf-8")
+    if six.PY2:
+      self.study_name = study_name.encode("utf-8")
+    else:
+      self.study_name = study_name
     self.name = name
     self.parameter_values = parameter_values
     self.objective_value = objective_value

--- a/advisor_client/advisor_client/runner/runner_launcher.py
+++ b/advisor_client/advisor_client/runner/runner_launcher.py
@@ -3,6 +3,7 @@ import yaml
 import logging
 import subprocess
 import coloredlogs
+import six
 
 from .abstract_runner import AbstractRunner
 from .local_runner import LocalRunner
@@ -50,7 +51,10 @@ class RunnerLauncher():
         runner = LocalRunner()
         logging.info("Run with local runner")
 
-    study_name = self.run_config_dict["name"].encode("utf-8")
+    if six.PY2:
+      study_name = self.run_config_dict["name"].encode("utf-8")
+    else:
+      study_name = self.run_config_dict["name"]
     study = client.get_or_create_study(study_name,
                                        self.run_config_dict["search_space"],
                                        self.run_config_dict["algorithm"])
@@ -97,7 +101,10 @@ class RunnerLauncher():
 
         # Example: '0.0\n'
         # Example: 'Compute y = x * x - 3 * x + 2\nIput x is: 1.0\nOutput is: 0.0\n0.0\n'
-        command_output = subprocess.check_output(command_string, shell=True)
+        if six.PY2:
+          command_output = subprocess.check_output(command_string, shell=True)
+        else:
+          command_output = subprocess.check_output(command_string, universal_newlines=True, shell=True)
         # TODO: Log the output in the directory
         #logging.info("Get output of command: {}".format(command_output))
 

--- a/advisor_server/dashboard/views.py
+++ b/advisor_server/dashboard/views.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 import json
 import requests
 import platform
+import six
 
 from django.contrib import messages
 from django.shortcuts import redirect
@@ -93,8 +94,12 @@ def v1_study(request, study_name):
     tirals_response = requests.get(tirals_url)
 
     if response.ok and tirals_response.ok:
-      study = json.loads(response.content.decode("utf-8"))["data"]
-      trials = json.loads(tirals_response.content.decode("utf-8"))["data"]
+      if six.PY2:
+        study = json.loads(response.content.decode("utf-8"))["data"]
+        trials = json.loads(tirals_response.content.decode("utf-8"))["data"]
+      else:
+        study = json.loads(response.text)["data"]
+        trials = json.loads(tirals_response.text)["data"]
       context = {"success": True, "study": study, "trials": trials}
       return render(request, "study_detail.html", context)
     else:
@@ -161,9 +166,14 @@ def v1_trial(request, study_name, trial_id):
     tiral_metrics_response = requests.get(tiral_metrics_url)
 
     if response.ok and tiral_metrics_response.ok:
-      trial = json.loads(response.content.decode("utf-8"))["data"]
-      trial_metrics = json.loads(
-          tiral_metrics_response.content.decode("utf-8"))["data"]
+      if six.PY2:
+        trial = json.loads(response.content.decode("utf-8"))["data"]
+        trial_metrics = json.loads(
+            tiral_metrics_response.content.decode("utf-8"))["data"]
+      else:
+        trial = json.loads(response.text)["data"]
+        trial_metrics = json.loads(
+          tiral_metrics_response.text)["data"]
       context = {
           "success": True,
           "trial": trial,
@@ -188,7 +198,10 @@ def v1_trial(request, study_name, trial_id):
     response = requests.put(url, json=data)
     messages.info(request, response.content)
 
-    trial = json.loads(response.content.decode("utf-8"))["data"]
+    if six.PY2:
+      trial = json.loads(response.content.decode("utf-8"))["data"]
+    else:
+      trial = json.loads(response.text)["data"]
     context = {"success": True, "trial": trial, "trial_metrics": []}
     return render(request, "trial_detail.html", context)
   else:
@@ -226,7 +239,10 @@ def v1_study_trial_metric(request, study_name, trial_id, metric_id):
     response = requests.get(url)
 
     if response.ok:
-      trial_metric = json.loads(response.content.decode("utf-8"))["data"]
+      if six.PY2:
+        trial_metric = json.loads(response.content.decode("utf-8"))["data"]
+      else:
+        trial_metric = json.loads(response.text)["data"]
       context = {"success": True, "trial_metric": trial_metric}
       # TODO: Add the detail page of trial metric
       return render(request, "trial_detail.html", context)


### PR DESCRIPTION
Code failed to run on my python 3.6 environment, and it's caused by using bytes for places where str is expected for python 3. So change to choose bytes or str based on python 2 or 3. Now I can run advisor server through docker, then use python 3 advisor client to communicate with it. In other words, I can use python3.6 to "advisor run -f ./advisor_client/examples/python_function/config.json"