### PR TITLE
feat: Avoid redundant trials

### DIFF
--- a/advisor_server/suggestion/algorithm/base_hyperopt_algorithm.py
+++ b/advisor_server/suggestion/algorithm/base_hyperopt_algorithm.py
@@ -167,7 +167,7 @@ class BaseHyperoptAlgorithm(AbstractSuggestionAlgorithm):
     for i in range(number):
 
       # Example: {u'hidden2': [2], u'learning_rate': [0.04633366105812467], u'l1_normalization': [0.16858448611765364], u'optimizer': [3]}
-      vals = new_trials[0]['misc']['vals']
+      vals = new_trials[i]['misc']['vals']
 
       new_advisor_trial = Trial.create(study.name, "TpeTrial")
       parameter_values_json = {}


### PR DESCRIPTION
The new_trials looks like this. Thus we should not use the first item all the times.

```json
[
    {'state': 0, 'tid': 2, 'spec': None, 'result': {'status': 'new'
        }, 'misc': {'tid': 2, 'cmd': ('domain_attachment', 'FMinIter_Domain'), 'workdir': None, 'idxs': {'param-1': [
                    2
                ], 'param-2': [
                    2
                ], 'param-3': [
                    2
                ], 'param-4': [
                    2
                ]
            }, 'vals': {'param-1': [
                    2
                ], 'param-2': [
                    0
                ], 'param-3': [
                    2
                ], 'param-4': [
                    1.496156082719898
                ]
            }
        }, 'exp_key': None, 'owner': None, 'version': 0, 'book_time': None, 'refresh_time': None
    },
    {'state': 0, 'tid': 3, 'spec': None, 'result': {'status': 'new'
        }, 'misc': {'tid': 3, 'cmd': ('domain_attachment', 'FMinIter_Domain'), 'workdir': None, 'idxs': {'param-1': [
                    3
                ], 'param-2': [
                    3
                ], 'param-3': [
                    3
                ], 'param-4': [
                    3
                ]
            }, 'vals': {'param-1': [
                    0
                ], 'param-2': [
                    1
                ], 'param-3': [
                    0
                ], 'param-4': [
                    2.8898132037592097
                ]
            }
        }, 'exp_key': None, 'owner': None, 'version': 0, 'book_time': None, 'refresh_time': None
    }
]
```

Signed-off-by: Ce Gao <gaoce@caicloud.io>