### PR TITLE
Update urls.py

### DIFF
--- a/advisor_server/advisor/urls.py
+++ b/advisor_server/advisor/urls.py
@@ -24,8 +24,8 @@ urlpatterns = [
     # TODO: Redirect to dashboard instead of login page
     # url(r'^$', dashboard_views.home, name='home'),
     url(r'^$', include('dashboard.urls')),
-    url(r'^login/$', auth_views.login, name='login'),
-    url(r'^logout/$', auth_views.logout, name='logout'),
+    url(r'^login/$', auth_views.LoginView, name='login'),
+    url(r'^logout/$', auth_views.LogoutView, name='logout'),
     url(r'^oauth/', include('social_django.urls', namespace='social')),  # <--
     url(r'^admin/', admin.site.urls),
     url(r'^suggestion/', include('suggestion.urls')),


### PR DESCRIPTION
while running the command "./manage.py migrate" to run advisor from scratch on MacOS, I got  following error "AttributeError: module Django.contrib.auth.views has no attribute" therefore I made some changes in the script and now the server runs fine at the local system.